### PR TITLE
Graphs and bttreetests bugfixes

### DIFF
--- a/src/main/java/ar/edu/uns/cs/ed/tdas/tdagrafo/Graph.java
+++ b/src/main/java/ar/edu/uns/cs/ed/tdas/tdagrafo/Graph.java
@@ -64,6 +64,15 @@ public interface Graph<V,E> {
 	 * @throws InvalidVertexException si el vértice es inválido.
 	 */
 	public V replace(Vertex<V> v, V x);
+
+	/**
+	 * Reemplaza el rótulo de e por un rótulo x.
+	 * @param e Un arco
+	 * @param x Rótulo
+	 * @return El rótulo anterior del arco e al reemplazarlo por un rótulo x.
+	 * @throws InvalidEdgeException si el arco es inválido.
+	 */
+	public E replace(Edge<E> e, E x);
 	
 	/**
 	 * Inserta un nuevo vértice con rótulo x.

--- a/src/main/java/ar/edu/uns/cs/ed/tdas/tdagrafo/GraphD.java
+++ b/src/main/java/ar/edu/uns/cs/ed/tdas/tdagrafo/GraphD.java
@@ -1,6 +1,7 @@
 package ar.edu.uns.cs.ed.tdas.tdagrafo;
 
-
+import ar.edu.uns.cs.ed.tdas.excepciones.InvalidEdgeException;
+import ar.edu.uns.cs.ed.tdas.excepciones.InvalidVertexException;
 
 /**
  * Interface Grafo para grafos dirigidos.
@@ -71,6 +72,15 @@ public interface GraphD<V,E> {
 	 * @throws InvalidVertexException si el vértice es inválido.
 	 */
 	public V replace(Vertex<V> v, V x);
+	
+	/**
+	 * Reemplaza el rótulo de e por un rótulo x.
+	 * @param e Un arco
+	 * @param x Rótulo
+	 * @return El rótulo anterior del arco e al reemplazarlo por un rótulo x.
+	 * @throws InvalidEdgeException si el arco es inválido.
+	 */
+	public E replace(Edge<E> e, E x);
 	
 	/**
 	 * Inserta un nuevo vértice con rótulo x.

--- a/src/test/java/ar/edu/uns/cs/ed/tdas/tdaarbolbinario/BinaryTreeTests.java
+++ b/src/test/java/ar/edu/uns/cs/ed/tdas/tdaarbolbinario/BinaryTreeTests.java
@@ -136,8 +136,10 @@ public class BinaryTreeTests {
 	@Test
 	public void positions_onlyRoot_iterableSizeEqualsOne() throws InvalidOperationException {
 		binaryTree.createRoot(new Object());
+		Iterator<Position<Object>> it = binaryTree.positions().iterator();
 		int size = 0;
-		for (Position<Object> _ : binaryTree.positions()) {
+		while (it.hasNext()) {
+			it.next();
 			size++;
 		}
 		assertEquals("El método positions retorna una colección iterable con " + size

--- a/src/test/java/ar/edu/uns/cs/ed/tdas/tdagrafo/GraphTests.java
+++ b/src/test/java/ar/edu/uns/cs/ed/tdas/tdagrafo/GraphTests.java
@@ -270,7 +270,18 @@ public class GraphTests {
 	 */
 	@Test(expected = InvalidVertexException.class)
 	public void replace_nullVertex_throwsIVE() throws InvalidVertexException {
-		graph.replace(null, new Object());
+		Vertex<Object> v = null;
+		graph.replace(v, new Object());
+	}
+
+	/**
+	 * Comprueba que el método replace lanza InvalidVertexException con un
+	 * arco nulo.
+	 */
+	@Test(expected = InvalidEdgeException.class)
+	public void replace_nullEdge_throwsIEE() throws InvalidEdgeException {
+		Edge<Object> e = null;
+		graph.replace(e, new Object());
 	}
 
 	/**
@@ -286,6 +297,20 @@ public class GraphTests {
 	}
 
 	/**
+	 * Comprueba que el método replace retorna correctamente el elemento previo
+	 * en el arco pasado por parámetro.
+	 */
+	@Test
+	public void replace_validEdge_returnsOldElement() throws InvalidEdgeException {
+		Vertex<Object> v1 = graph.insertVertex(new Object());
+		Vertex<Object> v2 = graph.insertVertex(new Object());
+		Edge<Object> e = graph.insertEdge(v1, v2, o1);
+		assertEquals("El método replace no retorna el elemento previo en el arco pasado por parámetro.", o1,
+				graph.replace(e, new Object()));
+
+	}
+
+	/**
 	 * Comprueba que el método replace setea correctamente el nuevo elemento al
 	 * vértice pasado por parámetro.
 	 */
@@ -293,7 +318,20 @@ public class GraphTests {
 	public void replace_validVertex_setsNewElement() throws InvalidVertexException {
 		Vertex<Object> v1 = graph.insertVertex(new Object());
 		graph.replace(v1, o1);
-		assertEquals("El método replace no setea correctamente el nuevo elemento.", o1, v1.element());
+		assertEquals("El método replace no setea correctamente el nuevo elemento del vértice.", o1, v1.element());
+	}
+
+	/**
+	 * Comprueba que el método replace setea correctamente el nuevo elemento al
+	 * arco pasado por parámetro.
+	 */
+	@Test
+	public void replace_validEdge_setsNewElement() throws InvalidEdgeException {
+		Vertex<Object> v1 = graph.insertVertex(new Object());
+		Vertex<Object> v2 = graph.insertVertex(new Object());
+		Edge<Object> e = graph.insertEdge(v1, v2, new Object());
+		graph.replace(e, o1);
+		assertEquals("El método replace no setea correctamente el nuevo elemento del arco.", o1, e.element());
 	}
 
 	/**


### PR DESCRIPTION
Added `replace(...)` method for change edge elements (in both `Graph `and `GraphD `interfaces), and also added tests for such a method.

Additionally, replaced a for(each) loop in `BinaryTreeTests.java` that was using an anonyomus var (originally to avoid a warning about its unused status) with a while loop using `Iterator`, that doesn't need to declare any unused var. The underscore as var name appears to be unsupported for some older Java versions (not yet confirmed) as some students asked about the issue.