### PR TITLE
Suppressed Random behavior from test cases for Maps and Dictionaries

### DIFF
--- a/src/test/java/ar/edu/uns/cs/ed/tdas/tdadiccionario/DictionaryTest.java
+++ b/src/test/java/ar/edu/uns/cs/ed/tdas/tdadiccionario/DictionaryTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.*;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Random;
 import java.util.Set;
 import java.util.Vector;
 
@@ -197,7 +196,6 @@ public class DictionaryTest {
 		Integer valor, clave;
 		Vector<Vector<Integer>> V= new Vector<Vector<Integer>>(2);
 		Set<Integer> claves= new HashSet<Integer>();
-		Random r= new Random();
 		Entry<Integer,Integer> en;
 		boolean esta;
 		
@@ -225,9 +223,9 @@ public class DictionaryTest {
         V.add(new Vector<Integer>(1000));
 		try {
 			for (int i=0; i<1000;i++)
-				{clave=r.nextInt(10*(i+1));
+				{clave=i%300;
 				 claves.add(clave);
-				 valor=r.nextInt(1000);
+				 valor=i;
 				 V.get(0).add(clave);
 				 V.get(1).add(valor);
 				 s.insert(clave, valor);
@@ -290,7 +288,6 @@ public class DictionaryTest {
 		Integer valor, clave;
 		Vector<Vector<Integer>> V= new Vector<Vector<Integer>>(2);
 		Set<Integer> claves= new HashSet<Integer>();
-		Random r= new Random();
 		Iterator<Entry<Integer,Integer>> it;
 		Entry<Integer,Integer> en;
 		boolean esta;
@@ -319,9 +316,9 @@ public class DictionaryTest {
         V.add(new Vector<Integer>(1000));
 		try {
 			for (int i=0; i<1000;i++)
-				{clave=r.nextInt(10*(i+1));
+				{clave=i%300;
 				 claves.add(clave);
-				 valor=r.nextInt(1000);
+				 valor=i;
 				 V.get(0).add(clave);
 				 V.get(1).add(valor);
 				 s.insert(clave, valor);
@@ -361,7 +358,6 @@ public class DictionaryTest {
 		Integer valor, clave;
 		Vector<Vector<Integer>> V= new Vector<Vector<Integer>>(2);
 		Set<Integer> claves= new HashSet<Integer>();
-		Random r= new Random();
 		Entry<Integer,Integer> en=null;
 		boolean esta;
 		
@@ -407,9 +403,9 @@ public class DictionaryTest {
         V.add(new Vector<Integer>(1000));
 		try {
 			for (int i=0; i<1000;i++)
-				{clave=r.nextInt(10*(i+1));
+				{clave=i%300;
 				 claves.add(clave);
-				 valor=r.nextInt(1000);
+				 valor=i;
 				 V.get(0).add(clave);
 				 V.get(1).add(valor);
 				 s.insert(clave, valor);
@@ -454,7 +450,6 @@ public class DictionaryTest {
 		Integer valor, clave;
 		Vector<Vector<Integer>> V= new Vector<Vector<Integer>>(2);
 		Set<Integer> claves= new HashSet<Integer>();
-		Random r= new Random();
 		boolean esta;
 		
 	    //Diccionario vacío
@@ -466,9 +461,9 @@ public class DictionaryTest {
         V.add(new Vector<Integer>(1000));
 		try {
 			for (int i=0; i<1000;i++)
-				{clave=r.nextInt(10*(i+1));
+				{clave=i%300;
 				 claves.add(clave);
-				 valor=r.nextInt(1000);
+				 valor=i;
 				 V.get(0).add(clave);
 				 V.get(1).add(valor);
 				 s.insert(clave, valor);

--- a/src/test/java/ar/edu/uns/cs/ed/tdas/tdamapeo/MapTest.java
+++ b/src/test/java/ar/edu/uns/cs/ed/tdas/tdamapeo/MapTest.java
@@ -1,12 +1,3 @@
-
-/**
- * Class: MapTest
- * @author María Luján Ganuza (mlg@cs.uns.edu.ar)
- *         Estructuras de Datos _ Primer Cuatrimestre 2013
- *         Departamento de Cs. e Ing. de la Computación.
- *  @version: 2.0
- */
-
 package ar.edu.uns.cs.ed.tdas.tdamapeo;
 
 import ar.edu.uns.cs.ed.tdas.excepciones.*;
@@ -200,7 +191,6 @@ public class MapTest {
 		Integer valor, clave, valor_aux, clave_aux;
 		Vector<Vector<Integer>> V= new Vector<Vector<Integer>>(2);
 		Set<Integer> claves= new HashSet<Integer>();
-		Random r= new Random();
 		
 		//Clave inválida
 		try {
@@ -266,13 +256,9 @@ public class MapTest {
         V.add(new Vector<Integer>(10000));
 		try {
 			for (int i=0; i<10000;i++)
-				{clave=r.nextInt(10*(i+1));
-				 while(claves.contains(clave))
-				  	{
-				 	 clave=r.nextInt(10*(i+1));	 
-				 	}
+				{clave=i;
 				 claves.add(clave);
-				 valor=r.nextInt(10000);
+				 valor=i;
 				 V.get(0).add(clave);
 				 V.get(1).add(valor);
 				 s.put(clave, valor);
@@ -305,7 +291,6 @@ public class MapTest {
 	public void put_remove() {
 
 		Integer valor, clave, clave_aux, valor_aux;
-		Random r= new Random();
 		Vector<Vector<Integer>> V= new Vector<Vector<Integer>>(2);
 		Set<Integer> claves= new HashSet<Integer>();
 		
@@ -338,11 +323,9 @@ public class MapTest {
         V.add(new Vector<Integer>(10000));
 		try {
 			for (int i=0; i<10000;i++)
-				{clave=r.nextInt(10*(i+1));
-				 while(claves.contains(clave))
-					clave=r.nextInt(10*(i+1));	 
+				{clave=i; 
 				 claves.add(clave);
-				 valor=r.nextInt(10000);
+				 valor=i;
 				 V.get(0).add(clave);
 				 V.get(1).add(valor);
 				 s.put(clave, valor);
@@ -390,7 +373,6 @@ public class MapTest {
 	  Integer clave,valor;
 	  Set<Integer> claves= new HashSet<Integer>();
 	  Set<Integer> valores= new HashSet<Integer>();
-	  Random r=new Random();
 	  LinkedHashMap<Integer, Integer> entradas= new LinkedHashMap<Integer,Integer>();
 
 	  //Mapeo vacío
@@ -405,13 +387,9 @@ public class MapTest {
         //Insertando 10000 entradas en el mapeo		
     	try {
 			for (int i=0; i<10000;i++)
-				{ clave=r.nextInt(10*(i+1));
-				  while(claves.contains(clave))
-				  	 clave=r.nextInt(10*(i+1));	 
+				{ clave=i;
 			 	  claves.add(clave);
-				  valor=r.nextInt(10000);
-				  while(valores.contains(valor))
-				 	 valor=r.nextInt(10000);	 
+				  valor=i;
 				  valores.add(valor);
 				  entradas.put(clave, valor);
 				  s.put(clave, valor);


### PR DESCRIPTION
Eliminé el comportamiento aleatorio de los casos de prueba de Mapeos y Diccionarios.
El test de diccionario generaba problemas a algunos alumnos con un comportamiento errático, haciendo el conjunto de prueba frágil.

**Hipótesis (no confirmada)**: problema relacionado con el comportamiento del diccionario para entradas con igual clave-valor (si admite entradas duplicadas o no, y si en ese caso elimina una o todas al eliminar). Dependiendo de las claves y valores generados aleatoriamente se presentaban problemas sólo en algunas ejecuciones (dotando al conjunto de casos de prueba de un comportamiento intermitente).

Resolví eliminar la parte azarosa para que los casos de prueba sean determinísticos y no frágiles (como deben ser). Para esto se podría haber usado una semilla fija para el generador de números aleatorios, pero el azar en el testeo no incorpora nada relevante.